### PR TITLE
Add Quackback - open source feedback platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ A curated list of awesome tech resources for customer success professionals. Thi
 - **[UserVoice](https://www.uservoice.com/)** - Collects and prioritizes product feedback.
 - **[Hotjar](https://www.hotjar.com/)** - Heatmaps and user feedback to understand behavior.
 - **[feedback.tools](https://feedback.tools/)** - AI-powered platform to capture, organize, and prioritize user feedback from all channels.
+- **[Quackback](https://quackback.io/)** - Open source feedback platform with voting boards, public roadmaps, and changelogs.
 
 ## Data Analytics and Business Intelligence
 


### PR DESCRIPTION
Adds [Quackback](https://quackback.io/) to the Customer Feedback and Survey Tools section.

Quackback is an open source feedback platform with voting boards, public roadmaps, and changelogs. It helps teams collect, prioritize, and act on user feedback. AGPL-3.0 licensed, free to self-host.

GitHub: https://github.com/QuackbackIO/quackback