### PR TITLE
Add commsadvisor.com help desk software guide to Additional Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ A curated list of awesome tech resources for customer success professionals. Thi
 - **[HubSpot Resources](https://www.hubspot.com/resources/customer-success)** - Guides and templates.
 - **[Catalyst Blog](https://catalyst.io/blog)** - Insights on success management.
 - **[The CS Cafe Newsletter](https://www.thecscafe.com)** - Weekly Customer Success Newsletter by Hakan Ozturk.
+- **[Comms Advisor - Best Help Desk Software](https://commsadvisor.com/best-help-desk-software/)** - Comparison guide covering pricing, setup, and automation across top help desk platforms.
 
 ---
 


### PR DESCRIPTION
This adds a link to our help desk software comparison guide under Additional Resources. It covers setup time, pricing, and automation capabilities across the main small business help desk platforms, which seemed like a fit alongside the existing blogs and newsletters in that section. I run the site and I'm disclosing that here. Happy to adjust the description or placement if it doesn't fit the list's scope.